### PR TITLE
Let users select role during /start onboarding

### DIFF
--- a/src/bot/bot.ts
+++ b/src/bot/bot.ts
@@ -37,7 +37,7 @@ export const buildBot = () => {
   bot.use(heartbeat);
   bot.use(stage.middleware());
 
-  registerStart(bot, stage);
+  registerStart(bot);
   registerHelp(bot);
   registerSearch(bot, stage);
   registerRequestFlows(bot);

--- a/src/bot/commands/start.ts
+++ b/src/bot/commands/start.ts
@@ -1,16 +1,11 @@
-import { Telegraf, Scenes, Markup } from 'telegraf';
+import { Telegraf, Markup } from 'telegraf';
 import { prisma } from '../../services/prisma.js';
 import { roleKeyboard } from '../keyboards.js';
 
-export const registerStart = (bot: Telegraf, stage: Scenes.Stage) => {
+export const registerStart = (bot: Telegraf) => {
   bot.start(async (ctx) => {
     if (!ctx.from) return;
     const tgId = String(ctx.from.id);
-    const existed = await prisma.user.findUnique({ where: { tgId } });
-    if (!existed) {
-      await prisma.user.create({ data: { tgId, username: ctx.from.username ?? undefined } });
-    }
-
     const u = await prisma.user.findUnique({ where: { tgId } });
     if (!u?.role) {
       await ctx.reply(
@@ -62,12 +57,12 @@ export const registerStart = (bot: Telegraf, stage: Scenes.Stage) => {
 
   bot.action('role_client', async (ctx) => {
     await ctx.answerCbQuery();
-    await ctx.scene.enter('clientOnboarding');
+    await (ctx as any).scene.enter('clientOnboarding');
   });
 
   bot.action('role_performer', async (ctx) => {
     await ctx.answerCbQuery();
-    await ctx.scene.enter('performerOnboarding');
+    await (ctx as any).scene.enter('performerOnboarding');
   });
 
 };


### PR DESCRIPTION
## Summary
- prevent automatic CLIENT creation on /start
- create or update user with chosen role during client onboarding
- simplify start command signature

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: TypeScript errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b348c270832e814a80a7aec20c9e