### PR TITLE
fix: avoid auto client role assignment in heartbeat

### DIFF
--- a/src/bot/middleware/heartbeat.ts
+++ b/src/bot/middleware/heartbeat.ts
@@ -1,24 +1,20 @@
-import { MiddlewareFn } from 'telegraf';
+import { Context, MiddlewareFn } from 'telegraf';
 import { prisma } from '../../services/prisma.js';
 
 /**
  * Обновляет lastSeenAt для каждого апдейта, чтобы можно было фильтровать "онлайн"
  * (условно: lastSeenAt > now - 10 минут).
  */
-export const heartbeat: MiddlewareFn = async (ctx, next) => {
+export const heartbeat: MiddlewareFn<Context> = async (ctx, next) => {
   try {
     if (ctx.from) {
-      await prisma.user.upsert({
+      await prisma.user.update({
         where: { tgId: String(ctx.from.id) },
-        update: { lastSeenAt: new Date(), username: ctx.from.username ?? undefined },
-        create: {
-          tgId: String(ctx.from.id),
-          role: 'CLIENT',
-          username: ctx.from.username ?? undefined,
-          lastSeenAt: new Date(),
-        },
+        data: { lastSeenAt: new Date(), username: ctx.from.username ?? undefined },
       });
     }
-  } catch {}
+  } catch {
+    // ignore errors: user might not exist yet
+  }
   return next();
 };


### PR DESCRIPTION
## Summary
- stop creating new users in heartbeat middleware to keep onboarding role selection intact

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Property 'session' does not exist ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b5ba3a44832ea32a1c777360c1b3