### PR TITLE
feat: switch performer photos to single url

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -66,8 +66,8 @@ model PerformerProfile {
   ranks                  Json?
   pricePerHour           Int
   about                  String?
-  voiceSampleUrl         String?
-  photos                 String[]
+  voiceSampleUrl         String      @default("")
+  photoUrl               String      @default("")
   availability           Json?
   status                 ListingStatus  @default(DRAFT)
   rating                 Float          @default(0)

--- a/src/bot/autoChecks.ts
+++ b/src/bot/autoChecks.ts
@@ -23,7 +23,7 @@ export async function runProfileAutoChecks(performerId: number): Promise<AutoChe
   const about = p.about || '';
   if (BANNED_PATTERNS.some((rx) => rx.test(about))) reasons.push('NSFW/Adult в описании');
   if (CONTACT_PATTERNS.some((rx) => rx.test(about))) reasons.push('Запрещённый обмен контактами в описании');
-  if ((p.photos?.length || 0) > 8) reasons.push('Слишком много фото (лимит 8)');
+  if (!p.photoUrl) reasons.push('Нет фото');
   if ((p.games?.length || 0) === 0) reasons.push('Не выбраны игры');
 
   const flagged = reasons.length > 0;

--- a/src/bot/commands/gallery.ts
+++ b/src/bot/commands/gallery.ts
@@ -2,7 +2,6 @@ import { Telegraf, Markup } from 'telegraf';
 import { prisma } from '../../services/prisma.js';
 import { runProfileAutoChecks } from '../autoChecks.js';
 
-const MAX_PHOTOS = 8;
 const MAX_IMAGE_MB = 4;
 const MAX_VOICE_MB = 2;
 const MAX_VOICE_SEC = 30;
@@ -10,8 +9,7 @@ const MAX_VOICE_SEC = 30;
 function kb() {
   return Markup.inlineKeyboard([
     [Markup.button.callback('➕ Добавить фото', 'gal_add_photo')],
-    [Markup.button.callback('🗑 Удалить последнее фото', 'gal_del_last')],
-    [Markup.button.callback('🧹 Очистить все фото', 'gal_clear')],
+    [Markup.button.callback('🗑 Удалить фото', 'gal_del_last')],
     [Markup.button.callback('🎤 Загрузить голосовую пробу', 'gal_add_voice')],
     [Markup.button.callback('📋 Показать текущее', 'gal_show')],
   ]);
@@ -28,11 +26,11 @@ export const registerGalleryCommand = (bot: Telegraf) => {
     const p = me.performerProfile;
     await ctx.reply(
       [
-        '📷 Галерея и голосовая проба',
-        `Фото: ${(p.photos?.length || 0)}/${MAX_PHOTOS}`,
+        '📷 Фото и голосовая проба',
+        `Фото: ${p.photoUrl ? 1 : 0}/1`,
         p.voiceSampleUrl ? '🎤 Голосовая проба загружена' : '🎤 Голосовая проба: нет',
         '',
-        'Добавьте до 8 фото (до 4 МБ каждое). Голосовую пробу — до 30 секунд и 2 МБ.',
+        'Добавьте фото (до 4 МБ). Голосовую пробу — до 30 секунд и 2 МБ.',
       ].join('\n'),
       kb(),
     );
@@ -50,7 +48,7 @@ export const registerGalleryCommand = (bot: Telegraf) => {
     if (data === 'gal_show') {
       await ctx.answerCbQuery?.();
       await ctx.reply(
-        [`Фото: ${(p.photos?.length || 0)}/${MAX_PHOTOS}`, p.voiceSampleUrl ? '🎤 Голосовая проба: есть' : '🎤 Голосовая проба: нет'].join('\n'),
+        [`Фото: ${p.photoUrl ? 1 : 0}/1`, p.voiceSampleUrl ? '🎤 Голосовая проба: есть' : '🎤 Голосовая проба: нет'].join('\n'),
         kb(),
       );
       return;
@@ -65,19 +63,9 @@ export const registerGalleryCommand = (bot: Telegraf) => {
 
     if (data === 'gal_del_last') {
       await ctx.answerCbQuery?.();
-      const arr = [...(p.photos || [])];
-      if (!arr.length) { await ctx.reply('В галерее нет фото.'); return; }
-      arr.pop();
-      await prisma.performerProfile.update({ where: { id: p.id }, data: { photos: arr } });
-      await ctx.reply(`Удалил последнее. Фото: ${arr.length}/${MAX_PHOTOS}`);
-      await runProfileAutoChecks(p.id);
-      return;
-    }
-
-    if (data === 'gal_clear') {
-      await ctx.answerCbQuery?.();
-      await prisma.performerProfile.update({ where: { id: p.id }, data: { photos: [] } });
-      await ctx.reply('Галерея очищена.');
+      if (!p.photoUrl) { await ctx.reply('Фото отсутствует.'); return; }
+      await prisma.performerProfile.update({ where: { id: p.id }, data: { photoUrl: '' } });
+      await ctx.reply('Фото удалено.');
       await runProfileAutoChecks(p.id);
       return;
     }
@@ -132,15 +120,8 @@ export const registerGalleryCommand = (bot: Telegraf) => {
       }
     } catch {}
 
-    const arr = [...(perf.photos || [])];
-    if (arr.length >= MAX_PHOTOS) {
-      await ctx.reply(`Лимит фотографий: ${MAX_PHOTOS}. Удалите лишнее.`);
-      (ctx.session as any).awaitingPhotoFor = undefined;
-      return;
-    }
-    arr.push(`tg:${fileId}`);
-    await prisma.performerProfile.update({ where: { id: waiting }, data: { photos: arr } });
-    await ctx.reply(`Фото добавлено. Фото: ${arr.length}/${MAX_PHOTOS}`);
+    await prisma.performerProfile.update({ where: { id: waiting }, data: { photoUrl: `tg:${fileId}` } });
+    await ctx.reply(perf.photoUrl ? 'Фото обновлено.' : 'Фото добавлено.');
     (ctx.session as any).awaitingPhotoFor = undefined;
     await runProfileAutoChecks(waiting);
   });

--- a/src/bot/commands/search.ts
+++ b/src/bot/commands/search.ts
@@ -135,7 +135,7 @@ export const registerSearch = (bot: Telegraf, stage: Scenes.Stage) => {
       const kb: any[] = [];
       kb.push([Markup.button.callback('Оставить заявку', `req_pf:${p.userId}`)]);
       if (p.voiceSampleUrl?.startsWith('tg:')) kb.push([Markup.button.callback('🎤 Голос', `play_voice:${p.userId}`)]);
-      if ((p.photos?.length || 0) > 0) kb.push([Markup.button.callback('📷 Галерея', `view_gallery:${p.userId}`)]);
+      if (p.photoUrl) kb.push([Markup.button.callback('📷 Фото', `view_photo:${p.userId}`)]);
       kb.push([Markup.button.callback('Назад', 'view_back')]);
 
       await ctx.editMessageText(header, Markup.inlineKeyboard(kb));
@@ -175,27 +175,16 @@ export const registerSearch = (bot: Telegraf, stage: Scenes.Stage) => {
     }
 
     // Галерея
-    if (data.startsWith('view_gallery:')) {
+    if (data.startsWith('view_photo:')) {
       const userId = Number(data.split(':')[1]);
       const u = await prisma.user.findUnique({ where: { id: userId }, include: { performerProfile: true } });
-      const photos = u?.performerProfile?.photos || [];
+      const photo = u?.performerProfile?.photoUrl;
       await ctx.answerCbQuery?.();
-      if (!photos.length) { await ctx.reply('Галерея пуста.'); return; }
-      const media = photos.slice(0, 10).map((s, i) => ({
-        type: 'photo',
-        media: s.startsWith('tg:') ? s.slice(3) : s,
-        caption: i === 0 ? `Галерея (${photos.length} фото)` : undefined,
-      }));
+      if (!photo) { await ctx.reply('Фото недоступно.'); return; }
       try {
-        // @ts-ignore
-        await ctx.replyWithMediaGroup(media);
+        await ctx.replyWithPhoto(photo.startsWith('tg:') ? photo.slice(3) : photo);
       } catch {
-        for (const [i, s] of photos.entries()) {
-          try {
-            if (i === 0) await ctx.replyWithPhoto(s.startsWith('tg:') ? s.slice(3) : s, { caption: `Галерея (${photos.length} фото)` });
-            else await ctx.replyWithPhoto(s.startsWith('tg:') ? s.slice(3) : s);
-          } catch {}
-        }
+        await ctx.reply('Не удалось отправить фото.');
       }
       return;
     }

--- a/src/bot/scenes/performerOnboarding.ts
+++ b/src/bot/scenes/performerOnboarding.ts
@@ -99,7 +99,7 @@ export const performerOnboarding = new Scenes.WizardScene<Scenes.WizardContext &
         pricePerHour: price!,
         about,
         status: config.autoApprovePerformers ? 'ACTIVE' : 'MODERATION',
-        photos: [],
+        photoUrl: '',
         plan: 'BASIC',
         planUntil: trialUntil,
       },


### PR DESCRIPTION
## Summary
- use single `photoUrl` and require `voiceSampleUrl`
- update onboarding, search, gallery and checks to use the new field

## Testing
- `npx prisma migrate dev --name photo-url-single` *(fails: Can't reach database server at `localhost:5432`)*
- `npx prisma generate`
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a1cc287270832ebdd7b3086c1f02a1