### PR TITLE
Add voice sample auto-check

### DIFF
--- a/src/bot/autoChecks.ts
+++ b/src/bot/autoChecks.ts
@@ -24,6 +24,7 @@ export async function runProfileAutoChecks(performerId: number): Promise<AutoChe
   if (BANNED_PATTERNS.some((rx) => rx.test(about))) reasons.push('NSFW/Adult в описании');
   if (CONTACT_PATTERNS.some((rx) => rx.test(about))) reasons.push('Запрещённый обмен контактами в описании');
   if (!p.photoUrl) reasons.push('Нет фото');
+  if (!p.voiceSampleUrl) reasons.push('Нет голосового сэмпла');
   if ((p.games?.length || 0) === 0) reasons.push('Не выбраны игры');
 
   const flagged = reasons.length > 0;


### PR DESCRIPTION
## Summary
- flag profiles missing a voice sample during auto checks

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: TS errors in existing files)

------
https://chatgpt.com/codex/tasks/task_e_68a1d5b54c2c832ea670ec2e3e89c0d5