### PR TITLE
chore: remove awaiting payinfo state resets

### DIFF
--- a/src/bot/bot.ts
+++ b/src/bot/bot.ts
@@ -102,7 +102,6 @@ export const buildBot = () => {
   bot.command('listing', async (ctx) => ctx.scene.enter('performerListingWizard'));
 
   bot.command('cancel', async (ctx) => {
-    (ctx.session as any).awaitingPayInfoFor = undefined;
     (ctx.session as any).awaitingProofFor = undefined;
     (ctx.session as any).proxyRoomFor = undefined;
     (ctx.session as any).awaitingBillingProofFor = undefined;
@@ -111,7 +110,6 @@ export const buildBot = () => {
   });
   bot.action('wiz_cancel', async (ctx) => {
     await ctx.answerCbQuery();
-    (ctx.session as any).awaitingPayInfoFor = undefined;
     (ctx.session as any).awaitingProofFor = undefined;
     (ctx.session as any).proxyRoomFor = undefined;
     (ctx.session as any).awaitingBillingProofFor = undefined;


### PR DESCRIPTION
## Summary
- drop leftover `awaitingPayInfoFor` session resets from `/cancel` and wizard cancel
- ensure no other references to `awaitingPayInfoFor`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Argument of type 'MiddlewareFn<WizardContext<WizardSessionData> & { session: any; }, Update>'...)*

------
https://chatgpt.com/codex/tasks/task_e_68a1df05523c832eba00b940b47a9c07