### PR TITLE
feat: activate profile with basic plan

### DIFF
--- a/src/bot/moderation.ts
+++ b/src/bot/moderation.ts
@@ -198,7 +198,11 @@ export const registerModeration = (bot: Telegraf) => {
       }
       const p = await prisma.performerProfile.update({
         where: { id },
-        data: { status: 'ACTIVE' },
+        data: {
+          status: 'ACTIVE',
+          plan: 'BASIC',
+          planUntil: new Date(Date.now() + 60 * 24 * 60 * 60 * 1000),
+        },
         include: { user: true },
       });
       await ctx.answerCbQuery?.('Одобрено');
@@ -206,7 +210,7 @@ export const registerModeration = (bot: Telegraf) => {
       try {
         await ctx.telegram.sendMessage(
           Number(p.user.tgId),
-          'Ваша анкета одобрена и опубликована.',
+          'Анкета одобрена. Ваш 60‑дневный бесплатный период начался сегодня',
         );
       } catch {}
       return;


### PR DESCRIPTION
## Summary
- activate performer profile with basic plan and 60-day trial upon approval
- notify performers about the start of their free period

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Property 'session' does not exist, etc.)

------
https://chatgpt.com/codex/tasks/task_e_68a21bd21738832ebc756113f2e352b3