### PR TITLE
Handle moderation status in performer profiles

### DIFF
--- a/src/bot/commands/profile.ts
+++ b/src/bot/commands/profile.ts
@@ -16,6 +16,9 @@ export const registerProfileCommand = (bot: Telegraf) => {
         await ctx.reply('Профиль исполнительницы не найден. Запустите онбординг: /start');
         return;
       }
+      if (p.status === 'MODERATION') {
+        await ctx.reply('Анкета на модерации');
+      }
       const openCount = await prisma.request.count({
         where: { performerId: me.id, status: { in: ['NEW', 'NEGOTIATION', 'ACCEPTED'] } as any },
       });

--- a/src/bot/commands/search.ts
+++ b/src/bot/commands/search.ts
@@ -118,7 +118,9 @@ export const registerSearch = (bot: Telegraf, stage: Scenes.Stage) => {
     if (data.startsWith('view_pf:')) {
       const id = Number(data.split(':')[1]);
       const p = await prisma.performerProfile.findUnique({ where: { id }, include: { user: true } });
-      if (!p || p.status !== 'ACTIVE') { await ctx.answerCbQuery?.('Анкета недоступна'); return; }
+      if (!p) { await ctx.answerCbQuery?.('Анкета недоступна'); return; }
+      if (p.status === 'MODERATION') { await ctx.answerCbQuery?.('Анкета на модерации'); return; }
+      if (p.status !== 'ACTIVE') { await ctx.answerCbQuery?.('Анкета недоступна'); return; }
 
       const labels: string[] = [];
       if (p.isBoosted && p.boostUntil && new Date(p.boostUntil).getTime() > Date.now()) labels.push('🚀 Boost');

--- a/src/bot/scenes/performerListingWizard.ts
+++ b/src/bot/scenes/performerListingWizard.ts
@@ -24,6 +24,7 @@ async function showMenu(ctx: Scenes.WizardContext) {
   }
   await ctx.reply(
     [
+      p.status === 'MODERATION' ? 'Анкета на модерации' : undefined,
       `Статус: ${formatListingStatus(p.status)}`,
       `Цена: ${p.pricePerHour}₽/час`,
       `О себе: ${p.about ?? '—'}`,


### PR DESCRIPTION
## Summary
- Show "Анкета на модерации" when a performer's profile is under moderation
- Surface moderation notice in listing wizard menu
- Block viewing performer profiles under moderation in search results

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Property 'session' does not exist errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a21e133e98832e8772446e512047f5