### PR TITLE
fix: prevent heartbeat error when user not found

### DIFF
--- a/src/bot/middleware/heartbeat.ts
+++ b/src/bot/middleware/heartbeat.ts
@@ -6,15 +6,12 @@ import { prisma } from '../../services/prisma.js';
  * (условно: lastSeenAt > now - 10 минут).
  */
 export const heartbeat: MiddlewareFn<Context> = async (ctx, next) => {
-  try {
-    if (ctx.from) {
-      await prisma.user.update({
-        where: { tgId: String(ctx.from.id) },
-        data: { lastSeenAt: new Date(), username: ctx.from.username ?? undefined },
-      });
-    }
-  } catch {
-    // ignore errors: user might not exist yet
+  if (ctx.from) {
+    // updateMany does not throw if the user is missing
+    await prisma.user.updateMany({
+      where: { tgId: String(ctx.from.id) },
+      data: { lastSeenAt: new Date(), username: ctx.from.username ?? undefined },
+    });
   }
   return next();
 };


### PR DESCRIPTION
## Summary
- avoid Prisma update errors when heartbeat runs before user creation

## Testing
- `npm run build` *(fails: Property 'session' does not exist on type...)*

------
https://chatgpt.com/codex/tasks/task_e_68a1dc59dacc832eaaf5cd48e7ef6876