### PR TITLE
feat: show request time in moscow

### DIFF
--- a/src/bot/commands/requests.ts
+++ b/src/bot/commands/requests.ts
@@ -1,6 +1,6 @@
 import { Telegraf, Markup } from 'telegraf';
 import { prisma } from '../../services/prisma.js';
-import { formatRequestStatus } from '../utils/format.js';
+import { formatRequestStatus, dateLabelMsk } from '../utils/format.js';
 
 export const registerRequestsCommand = (bot: Telegraf) => {
   bot.command('requests', async (ctx) => {
@@ -34,6 +34,7 @@ export const registerRequestsCommand = (bot: Telegraf) => {
         await ctx.reply(
           [
             `#${r.id} · ${r.game} · ${r.durationMin} мин`,
+            `Дата: ${dateLabelMsk(r.createdAt)} (МСК)`,
             `Статус: ${formatRequestStatus(r.status)}`,
           ].join('\n'),
           Markup.inlineKeyboard(kb),
@@ -61,6 +62,7 @@ export const registerRequestsCommand = (bot: Telegraf) => {
         await ctx.reply(
           [
             `#${r.id} · ${r.game} · ${r.durationMin} мин`,
+            `Дата: ${dateLabelMsk(r.createdAt)} (МСК)`,
             `Статус: ${formatRequestStatus(r.status)}${paid}`,
           ].join('\n'),
           Markup.inlineKeyboard(kb),

--- a/src/bot/utils/format.ts
+++ b/src/bot/utils/format.ts
@@ -36,3 +36,17 @@ export function dateLabel(d?: Date | null, fallback = '—'): string {
   const z = (n: number) => String(n).padStart(2, '0');
   return `${d.getFullYear()}-${z(d.getMonth()+1)}-${z(d.getDate())} ${z(d.getHours())}:${z(d.getMinutes())}`;
 }
+
+export function dateLabelMsk(d?: Date | null, fallback = '—'): string {
+  if (!d) return fallback;
+  return d
+    .toLocaleString('ru-RU', {
+      timeZone: 'Europe/Moscow',
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+    .replace(',', '');
+}


### PR DESCRIPTION
## Summary
- display request creation time in Moscow timezone in /requests output
- add formatter for Moscow date-time labels

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: TS errors unrelated to changes)*

------
https://chatgpt.com/codex/tasks/task_e_68a228c25520832eacedb6807e533e19