### PR TITLE
feat: add friendly cancellation messages

### DIFF
--- a/src/bot/bot.ts
+++ b/src/bot/bot.ts
@@ -108,7 +108,7 @@ export const buildBot = () => {
     (ctx.session as any).awaitingBillingProofFor = undefined;
     (ctx.session as any).admProfRej = undefined;
     try { await (ctx as any).scene.leave(); } catch {}
-    await ctx.reply('Ок, остановил текущий шаг.');
+    await ctx.reply('🛑 Готово, шаг остановлен. Если что — я рядом! 😊');
   });
   bot.action('wiz_cancel', async (ctx) => {
     await ctx.answerCbQuery();
@@ -117,12 +117,12 @@ export const buildBot = () => {
     (ctx.session as any).awaitingBillingProofFor = undefined;
     (ctx.session as any).admProfRej = undefined;
     try { await (ctx as any).scene.leave(); } catch {}
-    await ctx.editMessageText('Действие отменено.');
+    await ctx.editMessageText('❌ Действие отменено. Всё под контролем! 😉');
   });
 
   bot.catch((err, ctx) => {
     logger.error({ err }, 'Unhandled bot error');
-    return ctx.reply('Что-то пошло не так.');
+    return ctx.reply('😕 Упс, что-то пошло не так. Попробуйте ещё раз позже.');
   });
 
   return bot;


### PR DESCRIPTION
## Summary
- Use emoji and friendly phrasing when a step is cancelled or an action fails

## Testing
- `npm test` (fails: Missing script: "test")
- `npx tsc -p . --noEmit` (fails: Argument of type 'MiddlewareFn<WizardContext<WizardSessionData> & { session: any; }, Update>' is not assignable...)


------
https://chatgpt.com/codex/tasks/task_e_68a243c33844832e82d8f4ecb91514fa