### PR TITLE
refactor: soften no reviews message

### DIFF
--- a/src/bot/reviews.ts
+++ b/src/bot/reviews.ts
@@ -150,7 +150,7 @@ export const registerReviewFlows = (bot: Telegraf) => {
       });
       if (!items.length) {
         await ctx.answerCbQuery?.();
-        await ctx.reply('Пока нет отзывов.');
+        await ctx.reply('Пока отзывов нет 😌');
         return;
       }
       await ctx.answerCbQuery?.();


### PR DESCRIPTION
## Summary
- use friendlier message when no reviews are available

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: Argument type errors in other files)

------
https://chatgpt.com/codex/tasks/task_e_68a243d01aec832eb457301e647070d5