### PR TITLE
Handle expiring boosts and plans

### DIFF
--- a/src/bot/billingAdmin.ts
+++ b/src/bot/billingAdmin.ts
@@ -1,5 +1,6 @@
 import { Telegraf, Markup } from 'telegraf';
 import { prisma } from '../services/prisma.js';
+import { clearExpiredStatuses } from '../services/performer.js';
 import { config } from '../config.js';
 
 const isAdmin = (tgId: string) => config.adminIds.includes(tgId);
@@ -10,6 +11,7 @@ async function activateOrder(orderId: number) {
     include: { performer: { include: { user: true } } },
   });
   if (!o) return null;
+  await clearExpiredStatuses(o.performerId);
   const now = new Date();
   const until = new Date(now.getTime() + o.days * 24 * 60 * 60 * 1000);
 

--- a/src/bot/commands/billing.ts
+++ b/src/bot/commands/billing.ts
@@ -22,11 +22,22 @@ export const registerBillingCommand = (bot: Telegraf) => {
       return;
     }
     const p = me.performerProfile;
+    const now = Date.now();
+    const planActive =
+      p.plan !== 'BASIC' && p.planUntil && new Date(p.planUntil).getTime() > now;
+    const boostActive =
+      p.isBoosted && p.boostUntil && new Date(p.boostUntil).getTime() > now;
     await ctx.reply(
       [
         '💳 Размещение и продвижение анкеты',
-        `Тариф: ${planTitle(p.plan as any)}${p.planUntil ? ` (до ${new Date(p.planUntil).toISOString().slice(0,10)})` : ''}`,
-        p.isBoosted && p.boostUntil ? `Буст активен до ${new Date(p.boostUntil).toISOString().slice(0,10)}` : 'Буст: нет',
+        `Тариф: ${planTitle((planActive ? p.plan : 'BASIC') as any)}${
+          planActive && p.planUntil
+            ? ` (до ${new Date(p.planUntil).toISOString().slice(0, 10)})`
+            : ''
+        }`,
+        boostActive
+          ? `Буст активен до ${new Date(p.boostUntil!).toISOString().slice(0, 10)}`
+          : 'Буст: нет',
         '',
         `Цены: буст 7д — ${config.billing.BOOST_7D_RUB}₽; STANDARD 30д — ${config.billing.PLAN_STD_30D_RUB}₽; PRO 30д — ${config.billing.PLAN_PRO_30D_RUB}₽.`,
       ].join('\n'),

--- a/src/bot/commands/search.ts
+++ b/src/bot/commands/search.ts
@@ -16,8 +16,15 @@ export const registerSearch = (bot: Telegraf, stage: Scenes.Stage) => {
 
   const formatProfile = (ctx: any, p: any) => {
     const labels: string[] = [];
-    if (p.isBoosted && p.boostUntil && new Date(p.boostUntil).getTime() > Date.now()) labels.push('🚀');
-    if (p.plan && p.plan !== 'BASIC') labels.push(p.plan === 'PRO' ? '🏆' : '⭐️');
+    const now = Date.now();
+    if (p.isBoosted && p.boostUntil && new Date(p.boostUntil).getTime() > now) labels.push('🚀');
+    if (
+      p.plan &&
+      p.plan !== 'BASIC' &&
+      p.planUntil &&
+      new Date(p.planUntil).getTime() > now
+    )
+      labels.push(p.plan === 'PRO' ? '🏆' : '⭐️');
     const rating = p.rating ? p.rating.toFixed(1) : '0.0';
     const title = `${labels.join(' ')} ${p.user.username ? '@' + p.user.username : 'ID ' + p.userId}`.trim();
     const lines = [title, `Цена: ${p.pricePerHour}₽/ч`, `Рейтинг: ${rating}`];
@@ -69,11 +76,18 @@ export const registerSearch = (bot: Telegraf, stage: Scenes.Stage) => {
     });
 
     // Домешаем вес плана вручную и сократим до 30
+    const now = Date.now();
     const profiles = raw
       .map((p) => ({
         p,
-        boostKey: p.boostUntil ? new Date(p.boostUntil).getTime() : 0,
-        planKey: planWeight[(p.plan as any) || 'BASIC'] || 0,
+        boostKey:
+          p.boostUntil && new Date(p.boostUntil).getTime() > now
+            ? new Date(p.boostUntil).getTime()
+            : 0,
+        planKey:
+          p.plan && p.planUntil && new Date(p.planUntil).getTime() > now
+            ? planWeight[(p.plan as any) || 'BASIC'] || 0
+            : 0,
         rating: p.rating || 0,
       }))
       .sort((a, b) => {
@@ -146,8 +160,15 @@ export const registerSearch = (bot: Telegraf, stage: Scenes.Stage) => {
       if (p.status !== 'ACTIVE') { await ctx.answerCbQuery?.('Анкета недоступна'); return; }
 
       const labels: string[] = [];
-      if (p.isBoosted && p.boostUntil && new Date(p.boostUntil).getTime() > Date.now()) labels.push('🚀 Boost');
-      if (p.plan && p.plan !== 'BASIC') labels.push(p.plan === 'PRO' ? '🏆 PRO' : '⭐️ STANDARD');
+      const now = Date.now();
+      if (p.isBoosted && p.boostUntil && new Date(p.boostUntil).getTime() > now) labels.push('🚀 Boost');
+      if (
+        p.plan &&
+        p.plan !== 'BASIC' &&
+        p.planUntil &&
+        new Date(p.planUntil).getTime() > now
+      )
+        labels.push(p.plan === 'PRO' ? '🏆 PRO' : '⭐️ STANDARD');
 
       const header = [
         `${labels.length ? labels.join(' · ') + ' · ' : ''}🎮 Анкета #${p.id}`,

--- a/src/services/performer.ts
+++ b/src/services/performer.ts
@@ -1,0 +1,20 @@
+import { prisma } from './prisma.js';
+
+/**
+ * Clears expired boost and plan statuses for performer profile.
+ * @param performerId performer profile identifier
+ */
+export async function clearExpiredStatuses(performerId: number) {
+  const now = new Date();
+
+  await prisma.performerProfile.updateMany({
+    where: { id: performerId, boostUntil: { lt: now } },
+    data: { isBoosted: false, boostUntil: null },
+  });
+
+  await prisma.performerProfile.updateMany({
+    where: { id: performerId, planUntil: { lt: now } },
+    data: { plan: 'BASIC', planUntil: null },
+  });
+}
+

--- a/src/tasks/expireBoostsPlans.ts
+++ b/src/tasks/expireBoostsPlans.ts
@@ -1,0 +1,25 @@
+import { prisma } from '../services/prisma.js';
+
+/**
+ * Daily job to reset expired boosts and plans.
+ * Should be run by a cron scheduler.
+ */
+export async function expireBoostsPlans() {
+  const now = new Date();
+
+  await prisma.performerProfile.updateMany({
+    where: { isBoosted: true, boostUntil: { lt: now } },
+    data: { isBoosted: false, boostUntil: null },
+  });
+
+  await prisma.performerProfile.updateMany({
+    where: { plan: { not: 'BASIC' }, planUntil: { lt: now } },
+    data: { plan: 'BASIC', planUntil: null },
+  });
+}
+
+// Execute if run directly
+if (import.meta.url === `file://${process.argv[1]}`) {
+  expireBoostsPlans().finally(() => prisma.$disconnect());
+}
+


### PR DESCRIPTION
## Summary
- check boost/plan expiration before displaying badges or sorting results
- add daily task to reset expired boosts and plans
- clear outdated statuses when activating billing orders

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Property 'session' does not exist on type ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a428fa93dc832eb0b9a71329f232be