### PR TITLE
feat: set standard plan on profile approval

### DIFF
--- a/src/bot/moderation.ts
+++ b/src/bot/moderation.ts
@@ -334,7 +334,7 @@ export const registerModeration = (bot: Telegraf) => {
         where: { id },
         data: {
           status: 'ACTIVE',
-          plan: 'STANDARD',
+          plan: 'PRO',
           planUntil: new Date(Date.now() + config.trialDays * 24 * 60 * 60 * 1000),
         },
         include: { user: true },
@@ -344,7 +344,7 @@ export const registerModeration = (bot: Telegraf) => {
       try {
         await ctx.telegram.sendMessage(
           Number(p.user.tgId),
-          `Анкета одобрена. Ваш ${config.trialDays}-дневный бесплатный период на плане STANDARD начался сегодня`,
+          `Анкета одобрена. Ваш ${config.trialDays}-дневный бесплатный период на плане PRO начался сегодня`,
         );
       } catch {}
       return;

--- a/src/bot/moderation.ts
+++ b/src/bot/moderation.ts
@@ -334,8 +334,8 @@ export const registerModeration = (bot: Telegraf) => {
         where: { id },
         data: {
           status: 'ACTIVE',
-          plan: 'BASIC',
-          planUntil: new Date(Date.now() + 60 * 24 * 60 * 60 * 1000),
+          plan: 'STANDARD',
+          planUntil: new Date(Date.now() + config.trialDays * 24 * 60 * 60 * 1000),
         },
         include: { user: true },
       });
@@ -344,7 +344,7 @@ export const registerModeration = (bot: Telegraf) => {
       try {
         await ctx.telegram.sendMessage(
           Number(p.user.tgId),
-          'Анкета одобрена. Ваш 60‑дневный бесплатный период начался сегодня',
+          `Анкета одобрена. Ваш ${config.trialDays}-дневный бесплатный период на плане STANDARD начался сегодня`,
         );
       } catch {}
       return;


### PR DESCRIPTION
## Summary
- default approved performers to STANDARD plan
- calculate trial end from `config.trialDays`
- inform performers of plan and trial duration

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a44b283618832eacf625dd4913936f