### PR TITLE
Clear inline keyboards after request actions

### DIFF
--- a/src/bot/requests.ts
+++ b/src/bot/requests.ts
@@ -147,6 +147,7 @@ export const registerRequestFlows = (bot: Telegraf) => {
         },
       });
       await ctx.editMessageText(`✅ Заявка #${id} принята. Вперёд к деталям!`);
+      await ctx.editMessageReplyMarkup(undefined);
 
       // Создаём комнату прокси-чата (без контактов)
       await ensureRoom(id, String(req.client.tgId), String(req.performer.tgId));
@@ -267,6 +268,7 @@ export const registerRequestFlows = (bot: Telegraf) => {
         include: { client: true },
       });
       await ctx.editMessageText(`❎ Заявка #${id} отклонена.`);
+      await ctx.editMessageReplyMarkup(undefined);
       await ctx.telegram.sendMessage(
         Number(req.client.tgId),
         `Заявка #${id} отклонена исполнителем.`,
@@ -464,6 +466,7 @@ export const registerRequestFlows = (bot: Telegraf) => {
       await ctx.editMessageText(
         "Отправьте скрин/фото/документ подтверждения оплаты одним сообщением.",
       );
+      await ctx.editMessageReplyMarkup(undefined);
       (ctx as any).session.awaitingProofFor = id;
       return;
     }
@@ -508,6 +511,7 @@ export const registerRequestFlows = (bot: Telegraf) => {
         data: { clientConfirmed: true },
       });
       await ctx.editMessageText("Спасибо! Вы подтвердили выполнение.");
+      await ctx.editMessageReplyMarkup(undefined);
       await finalizeIfDone(id);
       return;
     }
@@ -519,6 +523,7 @@ export const registerRequestFlows = (bot: Telegraf) => {
         data: { performerConfirmed: true },
       });
       await ctx.editMessageText("Спасибо! Вы подтвердили выполнение.");
+      await ctx.editMessageReplyMarkup(undefined);
       await finalizeIfDone(id);
       return;
     }


### PR DESCRIPTION
## Summary
- Clear inline keyboards when a request is accepted or rejected
- Remove action buttons after client marks payment and after session completion confirmations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4d4552c74832e963af61994a67d6a